### PR TITLE
Move Video selector back to gr.Video from gr.Text

### DIFF
--- a/app.py
+++ b/app.py
@@ -747,7 +747,7 @@ with gr.Blocks(css=css) as interface:
                         )
 
                     with gr.Box(visible=True) as input_video_group:
-                        video_input = gr.Text(
+                        video_input = gr.Video(
                             label="Target Video Path", interactive=True
                         )
                         with gr.Accordion("✂️ Trim video", open=False):


### PR DESCRIPTION
Allow for uploading videos through Gradio interface instead of requiring local file path to video.